### PR TITLE
Updated Helm, Sop, Kustomize and Argocd versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM registry.access.redhat.com/ubi9/ubi:9.4
 
 USER root
 
-ENV HELM_VERSION=3.16.1 \
-    KUSTOMIZE_VERSION=5.4.3 \
+ENV HELM_VERSION=3.16.2 \
+    KUSTOMIZE_VERSION=5.5.0 \
     AGE_VERSGION=1.2.0 \
-    SOPS_VERSION=3.9.0 \
+    SOPS_VERSION=3.9.1 \
     AVP_VERSION=1.18.1
 
 # Install git and friends

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image URL to use all building/pushing image targets
 REGISTRY ?= quay.io
 REPOSITORY ?= $(REGISTRY)/eformat/argocd-vault-sidecar
-TAG ?= 2.12.3 # match the argocd version tag
+TAG ?= 2.13.0 # match the argocd version tag
 
 IMG := $(REPOSITORY):$(TAG)
 


### PR DESCRIPTION
Argocd : 2.13.0
Helm : 3.16.2
SOPS : 3.9.1
Kustomise : 5.5.0